### PR TITLE
Feat/parser improvements

### DIFF
--- a/.nix/purebred-mailcap.nix
+++ b/.nix/purebred-mailcap.nix
@@ -1,5 +1,5 @@
-{ mkDerivation, attoparsec, base, lib, tasty, tasty-hunit, text
-, time
+{ mkDerivation, attoparsec, base, bytestring, case-insensitive, lib
+, tasty, tasty-hunit, text, time
 }:
 mkDerivation {
   pname = "purebred-mailcap";
@@ -7,11 +7,13 @@ mkDerivation {
   src = ./..;
   isLibrary = true;
   isExecutable = true;
-  libraryHaskellDepends = [ attoparsec base text ];
-  executableHaskellDepends = [ base text ];
+  libraryHaskellDepends = [
+    attoparsec base bytestring case-insensitive text
+  ];
+  executableHaskellDepends = [ base bytestring ];
   testHaskellDepends = [
     attoparsec base tasty tasty-hunit text time
   ];
-  license = "unknown";
-  hydraPlatforms = lib.platforms.none;
+  description = "A parser for parsing mailcap (RFC1524) files";
+  license = lib.licenses.agpl3Plus;
 }

--- a/flake.lock
+++ b/flake.lock
@@ -2,7 +2,7 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1631663639,
+        "lastModified": 1615797423,
         "narHash": "sha256-5NGDZXPQzuoxf/42NiyC9YwwhwzfMfIRrz3aT0XHzSc=",
         "owner": "nixos",
         "repo": "nixpkgs",
@@ -11,30 +11,14 @@
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable",
         "repo": "nixpkgs",
+        "rev": "266dc8c3d052f549826ba246d06787a219533b8f",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
-        "utils": "utils"
-      }
-    },
-    "utils": {
-      "locked": {
-        "lastModified": 1631561581,
-        "narHash": "sha256-3VQMV5zvxaVLvqqUrNz3iJelLw30mIVSfZmAaauM3dA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "7e5bf3925f6fbdfaf50a2a7ca0be2879c4261d19",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,41 @@
+{
+  description = "Purebred mailcap";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?rev=266dc8c3d052f549826ba246d06787a219533b8f";
+  };
+
+  outputs = { self, nixpkgs }: {
+
+    overlays = self: super: with super.haskell.lib; {
+      haskellPackages = super.haskell.packages.ghc884.override {
+        overrides = hself: hsuper: {
+          purebred-mailcap = hsuper.callPackage ./.nix/purebred-mailcap.nix { };
+        };
+      };
+    };
+
+    devShell.x86_64-linux =
+      with import nixpkgs { system = "x86_64-linux"; overlays = [ self.overlays ]; };
+      let
+        nativeBuildTools = with haskellPackages; [
+          cabal-install
+          cabal2nix
+          ghcid
+          hlint
+          haskell-language-server
+          ormolu
+          hie-bios
+        ];
+      in haskellPackages.shellFor {
+        withHoogle = true;
+        packages = haskellPackages: [ haskellPackages.purebred-mailcap ];
+        nativeBuildInputs = haskellPackages.purebred-mailcap.env.nativeBuildInputs ++ nativeBuildTools;
+      };
+
+      defaultPackage.x86_64-linux =
+        with import nixpkgs { system = "x86_64-linux"; overlays = [ self.overlays ]; };
+        haskellPackages.purebred-mailcap;
+
+  };
+}

--- a/src/Data/RFC1524.hs
+++ b/src/Data/RFC1524.hs
@@ -47,7 +47,7 @@ data Field
   | Edit B.ByteString
   | Test B.ByteString
   | X11Bitmap B.ByteString
-  | TextualNewlines B.ByteString
+  | TextualNewlines Bool
   | Description B.ByteString
   | XToken
   deriving (Show, Eq)
@@ -120,6 +120,7 @@ namedfield = composefield
              <|> x11bitmap
              <|> description
              <|> edit
+             <|> textualnewlines
 
 description :: Parser Field
 description = stringCI "description" *> equal *> mtext <&> Description
@@ -132,6 +133,18 @@ composetypedfield = stringCI "composetyped" *> equal *> mtext <&> ComposeTyped
 
 printfield :: Parser Field
 printfield = stringCI "print" *> equal *> mtext <&> Print
+
+textualnewlines :: Parser Field
+textualnewlines = stringCI "textualnewlines" *> equal *> truthy <&> TextualNewlines
+
+truthy :: Parser Bool
+truthy = (stringCI "True" $> True)
+         <|> stringCI "False" $> False
+         <|> (satisfy isTruthy $> True)
+         <|> mtext $> False
+  where
+    isTruthy :: Word8 -> Bool
+    isTruthy c = c == 49
 
 edit :: Parser Field
 edit = stringCI "edit" *> equal *> mtext <&> Edit

--- a/src/Data/RFC1524.hs
+++ b/src/Data/RFC1524.hs
@@ -13,6 +13,7 @@ module Data.RFC1524 (
   , Field (..)
   ) where
 
+import Prelude hiding (print)
 import Control.Applicative ((<|>))
 import Data.Attoparsec.ByteString
 import Data.Attoparsec.ByteString.Char8 (char8, isEndOfLine, isSpace_w8, skipSpace, stringCI, space, endOfLine)
@@ -113,9 +114,9 @@ field :: Parser Field
 field = skipSpaceOrQChar *> (flag <|> namedfield)
 
 namedfield :: Parser Field
-namedfield = composefield
-             <|> composetypedfield
-             <|> printfield
+namedfield = compose
+             <|> composetyped
+             <|> print
              <|> test
              <|> x11bitmap
              <|> description
@@ -125,14 +126,14 @@ namedfield = composefield
 description :: Parser Field
 description = stringCI "description" *> equal *> mtext <&> Description
 
-composefield :: Parser Field
-composefield = stringCI "compose" *> equal *> mtext <&> Compose
+compose :: Parser Field
+compose = stringCI "compose" *> equal *> mtext <&> Compose
 
-composetypedfield :: Parser Field
-composetypedfield = stringCI "composetyped" *> equal *> mtext <&> ComposeTyped
+composetyped :: Parser Field
+composetyped = stringCI "composetyped" *> equal *> mtext <&> ComposeTyped
 
-printfield :: Parser Field
-printfield = stringCI "print" *> equal *> mtext <&> Print
+print :: Parser Field
+print = stringCI "print" *> equal *> mtext <&> Print
 
 textualnewlines :: Parser Field
 textualnewlines = stringCI "textualnewlines" *> equal *> truthy <&> TextualNewlines

--- a/src/Data/RFC1524.hs
+++ b/src/Data/RFC1524.hs
@@ -70,8 +70,7 @@ mailcapentry = do
   semicolon
   skipSpace
   vc <- viewCommand <* (endOfLine <|> semicolon)
-  fields <- fieldList
-  pure $ MailcapEntry $ Entry ct vc fields
+  MailcapEntry . Entry ct vc <$> fieldList
 
 fieldList :: Parser [Field]
 fieldList = field `sepBy` char8 ';'

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -49,7 +49,10 @@ testFieldParsing =
           @?= Right (Comment "This is a comment "),
       testCase "mtext" $
         parseOnly mtext "rplay %s\\; exit 1"
-          @?= Right "rplay %s; exit 1"
+          @?= Right "rplay %s; exit 1",
+      testCase "mtext with newline" $
+        parseOnly mtext "rplay %s\n"
+          @?= Right "rplay %s"
     ]
 
 testEntryParsing :: TestTree
@@ -62,7 +65,7 @@ testEntryParsing =
             ( MailcapEntry $
                 Entry
                   { _contentType = "application/octet-stream",
-                    _viewCommand = "hexdump\n",
+                    _viewCommand = "hexdump",
                     _fields = []
                   }
             ),
@@ -76,7 +79,7 @@ testEntryParsing =
                     _fields =
                       [ Flag "needsterminal",
                         Flag "copiousoutput",
-                        X11Bitmap "\"/usr/lib/zmail\"\n"
+                        X11Bitmap "\"/usr/lib/zmail\""
                       ]
                   }
             ),
@@ -86,7 +89,7 @@ testEntryParsing =
             ( MailcapEntry $
                 Entry
                   { _contentType = "audio/*",
-                    _viewCommand = "rplay %s; exit 1\n",
+                    _viewCommand = "rplay %s; exit 1",
                     _fields = []
                   }
             ),
@@ -122,6 +125,26 @@ testEntryParsing =
                   { _contentType = "image/x-fax-g3",
                     _viewCommand = "",
                     _fields = [Print "printfax %s"]
+                  }
+            ),
+      testCase "textual new lines - truthy" $
+        parseOnly mailcapentry "application/x-backup; /usr/bin/backup %s; textualnewlines=1; test=test -n \"$DISPLAY\""
+          @?= Right
+            ( MailcapEntry $
+                Entry
+                  { _contentType = "application/x-backup",
+                    _viewCommand = "/usr/bin/backup %s",
+                    _fields = [TextualNewlines True, Test "test -n \"$DISPLAY\""]
+                  }
+            ),
+      testCase "textual new lines - falsy" $
+        parseOnly mailcapentry "application/x-backup; /usr/bin/backup %s; textualnewlines=0; test=test -n \"$DISPLAY\""
+          @?= Right
+            ( MailcapEntry $
+                Entry
+                  { _contentType = "application/x-backup",
+                    _viewCommand = "/usr/bin/backup %s",
+                    _fields = [TextualNewlines False, Test "test -n \"$DISPLAY\""]
                   }
             ),
       testCase "composetyped field" $


### PR DESCRIPTION
```
commit 56ca58fed4d8d30245eb9b847106fbec99a4d8c5
Author: Róman Joost <roman@bromeco.de>
Date:   Fri Dec 31 17:28:24 2021 +1000

    Make hlint happy

commit 94b5e6c4682baeb43ef10770bf35dadc559ed149
Author: Róman Joost <roman@bromeco.de>
Date:   Fri Dec 31 17:27:01 2021 +1000

    Use consistent naming

    Lets stick with the RFC1524 grammar

commit 4574965c5405076ff1fbda1a02fabba8f83fb08a
Author: Róman Joost <roman@bromeco.de>
Date:   Fri Dec 31 17:27:36 2021 +1000

    Parse textualnewlines

    This parses the `textualnewlines` named field.

commit 6bb2ea69afebd2f28644f97530229d7cba1cccd5
Author: Róman Joost <roman@bromeco.de>
Date:   Fri Dec 31 17:27:23 2021 +1000

    Fix parser in regards to newlines and fields

    The parser would include the end of line
    control characters as part of view commands and fields. That is wrong,
    because the parser would trip up with following new lines and
    semicolons.

    Instead, include possible preceeding semicolons or newlines in the
    parsing step even if we don't need them.

```