### PR TITLE
Fix formatting and produce nice end of input

### DIFF
--- a/src/Data/RFC1524.hs
+++ b/src/Data/RFC1524.hs
@@ -56,7 +56,7 @@ data Field
 type ViewCommand = T.Text
 
 parseMailcapfile :: B.ByteString -> Either String MailcapFile
-parseMailcapfile = parseOnly (mailcapfile <* endOfInput)
+parseMailcapfile = parseOnly (mailcapfile <* niceEndOfInput)
 
 mailcapfile :: Parser MailcapFile
 mailcapfile = many' mailcapline

--- a/src/Data/RFC1524/Internal.hs
+++ b/src/Data/RFC1524/Internal.hs
@@ -1,25 +1,26 @@
-module Data.RFC1524.Internal (
-  ContentType(..)
-  , parseContentType
-  , ci
-  , token) where
+module Data.RFC1524.Internal
+  ( ContentType (..),
+    parseContentType,
+    ci,
+    token,
+  )
+where
 
-import Data.String (IsString(fromString))
-import Data.Attoparsec.ByteString.Char8 (char8)
 import Data.Attoparsec.ByteString
-import qualified Data.ByteString.Char8 as C8
+import Data.Attoparsec.ByteString.Char8 (char8)
 import qualified Data.ByteString as B
+import qualified Data.ByteString.Char8 as C8
 import qualified Data.CaseInsensitive as CI
+import Data.String (IsString (fromString))
 
 -- borrowed from purebred-email
 data ContentType = ContentType (CI.CI B.ByteString) (CI.CI B.ByteString)
   deriving (Show, Eq)
 
-
 instance IsString ContentType where
   fromString = either err id . parseOnly parseContentType . C8.pack
-    where       
-    err msg = error $ "failed to parse Content-Type: " <> msg
+    where
+      err msg = error $ "failed to parse Content-Type: " <> msg
 
 parseContentType :: Parser ContentType
 parseContentType = do
@@ -32,9 +33,9 @@ parseContentType = do
 ci :: CI.FoldCase s => Parser s -> Parser (CI.CI s)
 ci = fmap CI.mk
 
--- | header token parser  
-token :: Parser B.ByteString     
-token =             
+-- | header token parser
+token :: Parser B.ByteString
+token =
   takeWhile1 (\c -> c >= 33 && c <= 126 && notInClass "()<>@,;:\\\"/[]?=" c)
 
 -- end --


### PR DESCRIPTION
```
commit 2d71ae53f8587031be73dd48ff666fecddbe6038 (HEAD -> fix/formatting, origin/fix/formatting)
Author: Róman Joost <roman@bromeco.de>
Date:   Sat Jan 8 14:54:42 2022 +1000

    Borrow existing function to produce nice end of input

    In case of failure, the default `endOfInput` produces not enough
    information to figure out where exactly the parsing errored. Use the
    `niceEndOfinput` from Purebred to produce a better message so debugging
    is easier.

    Note, this is slightly changed, because sometimes just knowing that the
    error happened at a whitespace char at offset X doesn't help much. Also
    show the remaining input so it's easier to figure out where exactly the
    error is.

commit 3141c56773f6e230407217ca63771ee02c58f9dd
Author: Róman Joost <roman@bromeco.de>
Date:   Sat Jan 8 14:36:41 2022 +1000

    Fix up formatting and trailing whitespace
```