### PR TITLE
Cleanup and Copyright headers

### DIFF
--- a/purebred-mailcap.cabal
+++ b/purebred-mailcap.cabal
@@ -9,9 +9,8 @@ description:
   .
   - RFC1524 mailcap files parsing
 
--- A URL where users can report bugs.
--- bug-reports:
-
+homepage:           https://github.com/purebred-mua/purebred-mailcap
+bug-reports:        https://github.com/purebred-mua/purebred-mailcap/issues
 license:            AGPL-3.0-or-later
 license-file:       LICENSE
 author:             Róman Joost
@@ -19,9 +18,13 @@ maintainer:         roman@bromeco.de
 tested-with:
   GHC ==8.8.4 || ==8.10.4 || ==9.0.1
 
-copyright:           Copyright 2021 Róman Joost
+copyright:           Copyright 2022 Róman Joost
 category:            Data, Email
 extra-source-files:  CHANGELOG.md
+
+source-repository head
+  type: git
+  location: https://github.com/purebred-mua/purebred-mailcap.git
 
 library
     exposed-modules:  Data.Mailcap
@@ -58,11 +61,6 @@ test-suite tests
 executable purebred-mailcap
     main-is:          Main.hs
 
-    -- Modules included in this executable, other than Main.
-    -- other-modules:
-
-    -- LANGUAGE extensions used by modules in this package.
-    -- other-extensions:
     build-depends:    base >= 4.11 && < 5
                     , bytestring
                     , purebred-mailcap

--- a/src/Data/Mailcap.hs
+++ b/src/Data/Mailcap.hs
@@ -1,3 +1,18 @@
+-- This file is part of purebred-mailcap
+-- Copyright (C) 2022 Róman Joost
+--
+-- purebred-mailcap is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 {-# LANGUAGE OverloadedStrings #-}
 
 module Data.Mailcap (

--- a/src/Data/Mailcap/Internal.hs
+++ b/src/Data/Mailcap/Internal.hs
@@ -1,3 +1,19 @@
+-- This file is part of purebred-mailcap
+-- Copyright (C) 2022 Róman Joost
+--
+-- purebred-mailcap is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+--
 module Data.Mailcap.Internal (
   ContentType(..)
   , parseContentType

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 -- This file is part of purebred-mailcap
--- Copyright (C) 2021 Róman Joost
+-- Copyright (C) 2022 Róman Joost
 --
--- purebred-email is free software: you can redistribute it and/or modify
+-- purebred-mailcap is free software: you can redistribute it and/or modify
 -- it under the terms of the GNU Affero General Public License as published by
 -- the Free Software Foundation, either version 3 of the License, or
 -- (at your option) any later version.


### PR DESCRIPTION
This is a simple cleanup commit. It's adding copyright headers and fills out additional fields in the cabal file.